### PR TITLE
fix: add keep-alive to connections

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,10 @@
+name: Publish NPM package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    uses: snapshot-labs/actions/.github/workflows/publish-npm.yml@main
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,5 +4,11 @@ on: [push]
 
 jobs:
   test:
+    strategy:
+      matrix:
+        target: ['16', '18', '20']
+
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
     secrets: inherit
+    with:
+      target: ${{ matrix.target }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/pineapple",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,7 +18,7 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
-    "cross-fetch": "^3.1.5"
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
-import fetch from 'cross-fetch';
+import fetch from 'node-fetch';
+import http from 'node:http';
+import https from 'node:https';
 
 const PINEAPPLE_URL = 'https://pineapple.fyi';
+const agentOptions = { keepAlive: true };
 
 export async function pin(json: any, url: string = PINEAPPLE_URL) {
   const init = {
@@ -14,7 +17,11 @@ export async function pin(json: any, url: string = PINEAPPLE_URL) {
       method: 'pin',
       params: json,
       id: null
-    })
+    }),
+    agent:
+      new URL(url).protocol === 'http:'
+        ? new http.Agent(agentOptions)
+        : new https.Agent(agentOptions)
   };
   const res = await fetch(url, init);
   const content = await res.json();

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -10,7 +10,7 @@ describe('upload()', () => {
       formData.append('file', createReadStream(path.join(__dirname, './fixtures/valid.png')));
       const receipt = await upload(formData);
       expect(receipt.provider).toBe('4everland');
-      expect(receipt.cid).toBe('bafkreibenzwnm4pckgeqdyzlwnxemfavkofaynnpxj6o23oojcfe77hvte');
+      expect(receipt.cid).toBe('bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi');
     }, 30e3);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,7 +2725,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@2:
+node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,13 +1240,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2732,10 +2725,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -3327,7 +3320,7 @@ tr46@^2.1.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-jest@^27.1.4:
   version "27.1.5"
@@ -3459,7 +3452,7 @@ walker@^1.0.7:
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"
@@ -3486,7 +3479,7 @@ whatwg-mimetype@^2.3.0:
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Similar to the works done on keycard.js (https://github.com/snapshot-labs/keycard.js/pull/8), this PR will add the keep-alive feature to connections to pineapple server.

## 💊 Fixes / Solution

Fix https://github.com/snapshot-labs/pineapple/issues/164
Fix SNAPSHOT-SEQUENCER-H

## 🚧 Changes

- Migrate from `cross-fetch` to `node-fetch`
- Add custom http agent to fetch request
- the custom http agent has keepAlive enabled
- Fix tests (4everland is now returning a different CID for the exact same file, for unknown reasons)
- Tests on node 18 and 20

## 🛠️ Tests

- Same as the keycard.js PR