### PR TITLE
chore: auto version bump, tag and release

### DIFF
--- a/.github/workflows/bump-tag-publish.yml
+++ b/.github/workflows/bump-tag-publish.yml
@@ -1,0 +1,25 @@
+name: Bump, tag and publish to npm
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  bump-version:
+    uses: snapshot-labs/actions/.github/workflows/bump-version.yml@main
+    secrets: inherit
+
+  create-github-release:
+    uses: snapshot-labs/actions/.github/workflows/create-github-release.yml@main
+    if: startsWith(needs.bump-version.outputs.tag, 'v')
+    needs: bump-version
+    secrets: inherit
+    with:
+      tag_name: ${{ needs.bump-version.outputs.tag }}
+
+  publish-npm:
+    uses: snapshot-labs/actions/.github/workflows/publish-npm.yml@main
+    if: startsWith(needs.bump-version.outputs.tag, 'v')
+    needs: [bump-version, create-github-release]
+    secrets: inherit


### PR DESCRIPTION
This PR adds a new github workflow which will run when pushing on `master`.

The workflow will: 

- bump the version inside package.json (bump type will depends on commit messages, and follow semver)
- create a new tag with the new version
- create a release with the new tag
- publish the release on NPM

This will completely separate the release workflow, and bumping the package.json manually will not be needed anymore.

### Waiting for 

- [ ] https://github.com/snapshot-labs/actions/pull/11
- [ ] https://github.com/snapshot-labs/actions/pull/13

Do not merge until those PR are online