### PR TITLE
feat: add support for pinning on swarm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,7 @@ export function upload(body: any, url = `${PINEAPPLE_URL}/upload`) {
 }
 
 async function sendRequest(url: string, requestParams: RequestParams) {
-  if (
-    requestParams.body?.protocol &&
-    !AVAILABLE_PROTOCOLS.includes(requestParams.body.protocol)
-  ) {
+  if (requestParams.body?.protocol && !AVAILABLE_PROTOCOLS.includes(requestParams.body.protocol)) {
     return Promise.reject({
       error: {
         code: 400,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,23 @@
 import { ofetch as fetch } from 'ofetch';
 import { STATUS_CODE } from './utils';
 
-const PINEAPPLE_URL = 'https://pineapple.fyi';
+type Options = { protocol?: 'ipfs' | 'swarm' };
+
+type RequestParams = {
+  method: string;
+  headers?: Record<string, string>;
+  body?: any;
+  timeout?: number;
+};
+
 const timeout = 10e3;
 const defaultOptions = { retry: 2, retryDelay: 500, retryStatusCodes: [504] };
+const PINEAPPLE_URL = 'https://pineapple.fyi';
+const DEFAULT_PROTOCOL = 'ipfs';
+const AVAILABLE_PROTOCOLS = ['ipfs', 'swarm'];
 
-export function pin(json: any, url = PINEAPPLE_URL) {
-  const options = {
+export function pin(json: any, url = PINEAPPLE_URL, options: Options = {}) {
+  const requestParams: RequestParams = {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -16,23 +27,36 @@ export function pin(json: any, url = PINEAPPLE_URL) {
       jsonrpc: '2.0',
       method: 'pin',
       params: json,
+      protocol: options.protocol || DEFAULT_PROTOCOL,
       id: null
     },
     timeout
   };
 
-  return sendRequest(url, options);
+  return sendRequest(url, requestParams);
 }
 
 export function upload(body: any, url = `${PINEAPPLE_URL}/upload`) {
-  const options = { method: 'POST', body, timeout };
+  const requestParams: RequestParams = { method: 'POST', body, timeout };
 
-  return sendRequest(url, options);
+  return sendRequest(url, requestParams);
 }
 
-async function sendRequest(url: string, options: any) {
+async function sendRequest(url: string, requestParams: RequestParams) {
+  if (
+    requestParams.body?.protocol &&
+    !AVAILABLE_PROTOCOLS.includes(requestParams.body.protocol)
+  ) {
+    return Promise.reject({
+      error: {
+        code: 400,
+        message: `Invalid protocol: ${requestParams.body.protocol}.`
+      }
+    });
+  }
+
   try {
-    return (await fetch(url, { ...defaultOptions, ...options })).result;
+    return (await fetch(url, { ...defaultOptions, ...requestParams })).result;
   } catch (e: any) {
     return Promise.reject({
       error: e.data?.error || {

--- a/test/pin.test.ts
+++ b/test/pin.test.ts
@@ -1,10 +1,35 @@
 import { pin } from '../src';
 
+const PINEAPPLE_URL = process.env.PINEAPPLE_URL ?? 'https://pineapple.fyi';
+
 describe('pin()', () => {
-  it('pins and return the provider and cid', async () => {
+  it('pins on IPFS and return the provider and cid', async () => {
     const json = { name: 'Vitalik' };
     const receipt = await pin(json);
     expect(receipt.provider).toBe('4everland');
-    expect(receipt.cid).toBe('bafkreibatgmdqdxsair3j52zfhtntegshtypq2qbex3fgtorwx34kzippe');
+    expect(receipt.cid).toBe(
+      'bafkreibatgmdqdxsair3j52zfhtntegshtypq2qbex3fgtorwx34kzippe'
+    );
+  });
+
+  it('pins on swarm and return the provider and cid', async () => {
+    const json = { name: 'Vitalik' };
+    const receipt = await pin(json, PINEAPPLE_URL, { protocol: 'swarm' });
+    expect(receipt.provider).toBe('swarmy');
+    expect(receipt.cid).toBe(
+      'e4135e1002b35bc64d91c35084406fdfcc76e28d6d80256ba50ce0ffe72ee841'
+    );
+  });
+
+  it('throws error for invalid protocol', async () => {
+    const json = { name: 'Vitalik' };
+    await expect(
+      pin(json, PINEAPPLE_URL, { protocol: 'invalid' as any })
+    ).rejects.toEqual({
+      error: {
+        code: 400,
+        message: 'Invalid protocol: invalid.'
+      }
+    });
   });
 });

--- a/test/pin.test.ts
+++ b/test/pin.test.ts
@@ -7,25 +7,19 @@ describe('pin()', () => {
     const json = { name: 'Vitalik' };
     const receipt = await pin(json);
     expect(receipt.provider).toBe('4everland');
-    expect(receipt.cid).toBe(
-      'bafkreibatgmdqdxsair3j52zfhtntegshtypq2qbex3fgtorwx34kzippe'
-    );
+    expect(receipt.cid).toBe('bafkreibatgmdqdxsair3j52zfhtntegshtypq2qbex3fgtorwx34kzippe');
   });
 
   it('pins on swarm and return the provider and cid', async () => {
     const json = { name: 'Vitalik' };
     const receipt = await pin(json, PINEAPPLE_URL, { protocol: 'swarm' });
     expect(receipt.provider).toBe('swarmy');
-    expect(receipt.cid).toBe(
-      'e4135e1002b35bc64d91c35084406fdfcc76e28d6d80256ba50ce0ffe72ee841'
-    );
+    expect(receipt.cid).toBe('e4135e1002b35bc64d91c35084406fdfcc76e28d6d80256ba50ce0ffe72ee841');
   });
 
   it('throws error for invalid protocol', async () => {
     const json = { name: 'Vitalik' };
-    await expect(
-      pin(json, PINEAPPLE_URL, { protocol: 'invalid' as any })
-    ).rejects.toEqual({
+    await expect(pin(json, PINEAPPLE_URL, { protocol: 'invalid' as any })).rejects.toEqual({
       error: {
         code: 400,
         message: 'Invalid protocol: invalid.'

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -85,4 +85,23 @@ describe('upload()', () => {
       );
     });
   });
+
+  describe('when the protocol is not supported', () => {
+    it('returns an error', async () => {
+      const formData = new FormData();
+      formData.append('file', createReadStream(path.join(__dirname, './fixtures/valid.png')));
+      formData.append('protocol', 'swarm');
+
+      expect.assertions(1);
+
+      await expect(upload(formData)).rejects.toEqual(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            code: 500,
+            message: 'Unsupported provider type: image for protocol: swarm'
+          })
+        })
+      );
+    });
+  });
 });

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -7,10 +7,15 @@ describe('upload()', () => {
   describe('when the file is valid', () => {
     it('uploads and return the provider and cid', async () => {
       const formData = new FormData();
-      formData.append('file', createReadStream(path.join(__dirname, './fixtures/valid.png')));
+      formData.append(
+        'file',
+        createReadStream(path.join(__dirname, './fixtures/valid.png'))
+      );
       const receipt = await upload(formData);
       expect(receipt.provider).toBe('4everland');
-      expect(receipt.cid).toBe('bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi');
+      expect(receipt.cid).toBe(
+        'bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi'
+      );
     });
   });
 
@@ -35,7 +40,10 @@ describe('upload()', () => {
   describe('when the file is too big', () => {
     it('returns an error', async () => {
       const formData = new FormData();
-      formData.append('file', createReadStream(path.join(__dirname, './fixtures/too-heavy.jpg')));
+      formData.append(
+        'file',
+        createReadStream(path.join(__dirname, './fixtures/too-heavy.jpg'))
+      );
 
       expect.assertions(1);
 
@@ -53,7 +61,10 @@ describe('upload()', () => {
   describe('when the file is not an image', () => {
     it('returns an error', async () => {
       const formData = new FormData();
-      formData.append('file', createReadStream(path.join(__dirname, './fixtures/file.json')));
+      formData.append(
+        'file',
+        createReadStream(path.join(__dirname, './fixtures/file.json'))
+      );
 
       expect.assertions(1);
 
@@ -71,11 +82,16 @@ describe('upload()', () => {
   describe('on network error', () => {
     it('returns an error following the same format as server error', async () => {
       const formData = new FormData();
-      formData.append('file', createReadStream(path.join(__dirname, './fixtures/file.json')));
+      formData.append(
+        'file',
+        createReadStream(path.join(__dirname, './fixtures/file.json'))
+      );
 
       expect.assertions(1);
 
-      await expect(upload(formData, 'https://pineapple.fyi/not-existing')).rejects.toEqual(
+      await expect(
+        upload(formData, 'https://pineapple.fyi/not-existing')
+      ).rejects.toEqual(
         expect.objectContaining({
           error: expect.objectContaining({
             code: 404,

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -7,15 +7,10 @@ describe('upload()', () => {
   describe('when the file is valid', () => {
     it('uploads and return the provider and cid', async () => {
       const formData = new FormData();
-      formData.append(
-        'file',
-        createReadStream(path.join(__dirname, './fixtures/valid.png'))
-      );
+      formData.append('file', createReadStream(path.join(__dirname, './fixtures/valid.png')));
       const receipt = await upload(formData);
       expect(receipt.provider).toBe('4everland');
-      expect(receipt.cid).toBe(
-        'bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi'
-      );
+      expect(receipt.cid).toBe('bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi');
     });
   });
 
@@ -40,10 +35,7 @@ describe('upload()', () => {
   describe('when the file is too big', () => {
     it('returns an error', async () => {
       const formData = new FormData();
-      formData.append(
-        'file',
-        createReadStream(path.join(__dirname, './fixtures/too-heavy.jpg'))
-      );
+      formData.append('file', createReadStream(path.join(__dirname, './fixtures/too-heavy.jpg')));
 
       expect.assertions(1);
 
@@ -61,10 +53,7 @@ describe('upload()', () => {
   describe('when the file is not an image', () => {
     it('returns an error', async () => {
       const formData = new FormData();
-      formData.append(
-        'file',
-        createReadStream(path.join(__dirname, './fixtures/file.json'))
-      );
+      formData.append('file', createReadStream(path.join(__dirname, './fixtures/file.json')));
 
       expect.assertions(1);
 
@@ -82,16 +71,11 @@ describe('upload()', () => {
   describe('on network error', () => {
     it('returns an error following the same format as server error', async () => {
       const formData = new FormData();
-      formData.append(
-        'file',
-        createReadStream(path.join(__dirname, './fixtures/file.json'))
-      );
+      formData.append('file', createReadStream(path.join(__dirname, './fixtures/file.json')));
 
       expect.assertions(1);
 
-      await expect(
-        upload(formData, 'https://pineapple.fyi/not-existing')
-      ).rejects.toEqual(
+      await expect(upload(formData, 'https://pineapple.fyi/not-existing')).rejects.toEqual(
         expect.objectContaining({
           error: expect.objectContaining({
             code: 404,

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -10,7 +10,7 @@ describe('upload()', () => {
       formData.append('file', createReadStream(path.join(__dirname, './fixtures/valid.png')));
       const receipt = await upload(formData);
       expect(receipt.provider).toBe('4everland');
-      expect(receipt.cid).toBe('bafkreidxvfyqu6l3tb3y5gi2nq5zqyincpev2rangnv7nmaocrk7q3o2fi');
+      expect(receipt.cid).toBe('bafkreif6ai5u636rsxcyk45bqmmt263h35hpqakxays4pdzkfdbsdw7kva');
     });
   });
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/townhall/issues/17
Depends on https://github.com/snapshot-labs/pineapple/pull/226

This PR adds a new options argument to the `pin` function, allowing to choose on which protocol to pin the json content (`ipfs` (default) or `swarm`).